### PR TITLE
Refine AudioTube theming and playback experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,636 +1,128 @@
 <!DOCTYPE html>
-<html lang="id">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AudioTube - Streamlined YouTube Audio Player</title>
-    <style>
-        :root {
-            color-scheme: light;
-            --body-bg: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
-            --container-bg: rgba(255, 255, 255, 0.9);
-            --container-border: rgba(255, 255, 255, 0.35);
-            --container-shadow: 0 22px 48px rgba(15, 35, 95, 0.12);
-            --text-primary: #1c1c1e;
-            --text-secondary: #636366;
-            --glass-overlay: rgba(255, 255, 255, 0.5);
-            --input-bg: #f2f2f7;
-            --input-border: #d1d1d6;
-            --input-focus-ring: rgba(10, 132, 255, 0.18);
-            --button-primary: #0a84ff;
-            --button-primary-hover: #0060df;
-            --button-secondary: rgba(10, 132, 255, 0.12);
-            --button-secondary-text: #0a84ff;
-            --divider: rgba(60, 60, 67, 0.18);
-            --surface-muted: rgba(242, 242, 247, 0.85);
-            --status-playing: #30d158;
-            --status-paused: #ffd60a;
-            --status-loading: #0a84ff;
-            --status-error: #ff453a;
-            --terminal-bg: rgba(22, 22, 26, 0.92);
-            --terminal-text: #f5f5f7;
-            --terminal-prompt: #98a0ff;
-            --terminal-divider: rgba(245, 245, 247, 0.12);
-            --progress-track: rgba(142, 142, 147, 0.24);
-            --thumb-bg: #ffffff;
-            --card-outline: rgba(255, 255, 255, 0.25);
-        }
-
-        body[data-theme="dark"] {
-            color-scheme: dark;
-            --body-bg: radial-gradient(circle at 10% 20%, #1c1c25 0%, #05070c 100%);
-            --container-bg: rgba(28, 28, 30, 0.88);
-            --container-border: rgba(255, 255, 255, 0.06);
-            --container-shadow: 0 28px 60px rgba(0, 0, 0, 0.5);
-            --text-primary: #f5f5f7;
-            --text-secondary: #d1d1d6;
-            --glass-overlay: rgba(44, 44, 46, 0.6);
-            --input-bg: rgba(44, 44, 46, 0.9);
-            --input-border: rgba(255, 255, 255, 0.08);
-            --input-focus-ring: rgba(10, 132, 255, 0.32);
-            --button-primary: #0a84ff;
-            --button-primary-hover: #409cff;
-            --button-secondary: rgba(99, 230, 226, 0.12);
-            --button-secondary-text: #63e6e2;
-            --divider: rgba(255, 255, 255, 0.08);
-            --surface-muted: rgba(44, 44, 46, 0.86);
-            --terminal-bg: rgba(15, 15, 20, 0.95);
-            --terminal-text: #d8d8ff;
-            --terminal-prompt: #7dd3fc;
-            --terminal-divider: rgba(141, 141, 153, 0.2);
-            --progress-track: rgba(199, 199, 204, 0.25);
-            --thumb-bg: rgba(10, 132, 255, 1);
-            --card-outline: rgba(255, 255, 255, 0.08);
-        }
-
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-            background: var(--body-bg);
-            min-height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            padding: 28px 18px;
-            color: var(--text-primary);
-            transition: background 0.5s ease, color 0.3s ease;
-        }
-
-        .container {
-            background: var(--container-bg);
-            backdrop-filter: blur(26px) saturate(140%);
-            border-radius: 26px;
-            padding: 32px 28px 30px;
-            box-shadow: var(--container-shadow);
-            width: min(420px, 100%);
-            border: 1px solid var(--container-border);
-            position: relative;
-            overflow: hidden;
-        }
-
-        .container::before {
-            content: '';
-            position: absolute;
-            inset: 0;
-            background: linear-gradient(160deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.02));
-            opacity: 0.65;
-            pointer-events: none;
-        }
-
-        .header {
-            text-align: center;
-            margin-bottom: 22px;
-            position: relative;
-            z-index: 2;
-        }
-
-        .logo {
-            font-size: 2.2rem;
-            font-weight: 700;
-            background: linear-gradient(135deg, #0a84ff 10%, #5e5ce6 90%);
-            -webkit-background-clip: text;
-            color: transparent;
-            letter-spacing: -0.5px;
-        }
-
-        .subtitle {
-            color: var(--text-secondary);
-            font-size: 0.95rem;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-            margin-top: 6px;
-        }
-
-        .theme-toggle {
-            display: inline-flex;
-            padding: 4px;
-            background: var(--surface-muted);
-            border-radius: 18px;
-            border: 1px solid var(--card-outline);
-            margin: 0 auto 24px;
-            position: relative;
-            z-index: 2;
-        }
-
-        .theme-toggle button {
-            border: none;
-            background: transparent;
-            color: var(--text-secondary);
-            padding: 8px 14px;
-            font-size: 0.85rem;
-            font-weight: 600;
-            border-radius: 14px;
-            cursor: pointer;
-            transition: all 0.25s ease;
-        }
-
-        .theme-toggle button.active {
-            background: rgba(10, 132, 255, 0.18);
-            color: var(--text-primary);
-            box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
-        }
-
-        .input-section {
-            margin-bottom: 18px;
-            position: relative;
-            z-index: 2;
-        }
-
-        .url-input {
-            width: 100%;
-            padding: 14px 18px;
-            border: 1px solid var(--input-border);
-            border-radius: 16px;
-            font-size: 16px;
-            background: var(--input-bg);
-            color: var(--text-primary);
-            outline: none;
-            transition: border 0.2s ease, background 0.3s ease, box-shadow 0.2s ease;
-        }
-
-        .url-input:focus {
-            border-color: var(--button-primary);
-            background: rgba(255, 255, 255, 0.95);
-            box-shadow: 0 0 0 4px var(--input-focus-ring);
-        }
-
-        .error {
-            background: rgba(255, 69, 58, 0.14);
-            color: var(--status-error);
-            padding: 12px 16px;
-            border-radius: 14px;
-            margin: 10px 0 18px;
-            display: none;
-            font-size: 0.9rem;
-            border-left: 3px solid var(--status-error);
-        }
-
-        .button-row {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 10px;
-            margin-bottom: 20px;
-            position: relative;
-            z-index: 2;
-        }
-
-        .btn {
-            padding: 12px;
-            border-radius: 16px;
-            font-size: 15px;
-            font-weight: 600;
-            border: none;
-            cursor: pointer;
-            transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 6px;
-        }
-
-        .btn-primary {
-            background: var(--button-primary);
-            color: #fff;
-            box-shadow: 0 12px 18px rgba(10, 132, 255, 0.25);
-        }
-
-        .btn-primary:hover:not(:disabled) {
-            transform: translateY(-2px);
-            box-shadow: 0 18px 24px rgba(10, 132, 255, 0.28);
-            background: var(--button-primary-hover);
-        }
-
-        .btn-secondary {
-            background: var(--button-secondary);
-            color: var(--button-secondary-text);
-            border: 1px solid rgba(10, 132, 255, 0.24);
-        }
-
-        .btn-secondary:hover:not(:disabled) {
-            transform: translateY(-2px);
-            box-shadow: 0 14px 22px rgba(99, 230, 226, 0.25);
-        }
-
-        .btn:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-            transform: none !important;
-            box-shadow: none !important;
-        }
-
-        .loading {
-            text-align: center;
-            padding: 20px 16px;
-            display: none;
-            color: var(--text-secondary);
-        }
-
-        .spinner {
-            width: 26px;
-            height: 26px;
-            border: 3px solid rgba(10, 132, 255, 0.14);
-            border-top: 3px solid var(--button-primary);
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-            margin: 0 auto 12px;
-        }
-
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-
-        .player-card {
-            background: var(--surface-muted);
-            border-radius: 18px;
-            padding: 22px;
-            margin-bottom: 18px;
-            display: none;
-            position: relative;
-            z-index: 2;
-            border: 1px solid var(--card-outline);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-        }
-
-        .song-info {
-            text-align: center;
-            margin-bottom: 18px;
-        }
-
-        .song-title {
-            font-size: 1.15rem;
-            font-weight: 700;
-            color: var(--text-primary);
-            line-height: 1.35;
-            margin-bottom: 6px;
-        }
-
-        .song-status {
-            font-size: 0.92rem;
-            color: var(--text-secondary);
-        }
-
-        .progress-section {
-            margin-bottom: 22px;
-        }
-
-        .time-display {
-            display: flex;
-            justify-content: space-between;
-            margin-bottom: 10px;
-            font-size: 0.82rem;
-            color: var(--text-secondary);
-            font-weight: 600;
-        }
-
-        .progress-container {
-            position: relative;
-            height: 6px;
-            background: var(--progress-track);
-            border-radius: 3px;
-            cursor: pointer;
-            touch-action: none;
-        }
-
-        .progress-bar {
-            height: 100%;
-            background: linear-gradient(135deg, var(--button-primary) 10%, #5e5ce6 100%);
-            border-radius: 3px;
-            width: 0%;
-            transition: width 0.15s linear;
-        }
-
-        .progress-thumb {
-            position: absolute;
-            top: 50%;
-            left: 0%;
-            width: 18px;
-            height: 18px;
-            background: var(--thumb-bg);
-            border: 3px solid var(--button-primary);
-            border-radius: 50%;
-            transform: translate(-50%, -50%);
-            cursor: grab;
-            box-shadow: 0 4px 12px rgba(10, 132, 255, 0.25);
-            transition: transform 0.15s ease;
-            touch-action: none;
-        }
-
-        .progress-thumb:active {
-            cursor: grabbing;
-            transform: translate(-50%, -50%) scale(1.15);
-        }
-
-        .main-controls {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            gap: 28px;
-            margin-bottom: 22px;
-        }
-
-        .control-btn {
-            width: 52px;
-            height: 52px;
-            border-radius: 26px;
-            border: none;
-            background: rgba(255, 255, 255, 0.82);
-            color: var(--button-primary);
-            font-size: 24px;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            box-shadow: 0 10px 18px rgba(10, 132, 255, 0.18);
-            transition: transform 0.18s ease, box-shadow 0.18s ease;
-        }
-
-        .control-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 14px 26px rgba(10, 132, 255, 0.24);
-        }
-
-        .control-btn:active {
-            transform: scale(0.95);
-        }
-
-        .play-btn {
-            width: 66px;
-            height: 66px;
-            font-size: 30px;
-            background: var(--button-primary);
-            color: #fff;
-        }
-
-        .secondary-controls {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 18px;
-            flex-wrap: wrap;
-        }
-
-        .volume-control {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            flex: 1;
-            min-width: 0;
-        }
-
-        .volume-icon {
-            color: var(--text-secondary);
-            font-size: 18px;
-        }
-
-        .volume-slider {
-            flex: 1;
-            -webkit-appearance: none;
-            height: 6px;
-            border-radius: 3px;
-            background: var(--progress-track);
-            outline: none;
-            cursor: pointer;
-        }
-
-        .volume-slider::-webkit-slider-thumb {
-            -webkit-appearance: none;
-            width: 18px;
-            height: 18px;
-            border-radius: 50%;
-            background: var(--thumb-bg);
-            border: 3px solid var(--button-primary);
-            box-shadow: 0 3px 10px rgba(10, 132, 255, 0.2);
-        }
-
-        .volume-slider::-moz-range-thumb {
-            width: 18px;
-            height: 18px;
-            border-radius: 50%;
-            background: var(--thumb-bg);
-            border: 3px solid var(--button-primary);
-            box-shadow: 0 3px 10px rgba(10, 132, 255, 0.2);
-        }
-
-        .loop-toggle {
-            padding: 10px 18px;
-            border-radius: 20px;
-            border: 1px solid var(--card-outline);
-            background: rgba(10, 132, 255, 0.12);
-            color: var(--button-primary);
-            font-size: 0.9rem;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.2s ease;
-        }
-
-        .loop-toggle.active {
-            background: var(--button-primary);
-            color: #fff;
-            box-shadow: 0 14px 22px rgba(10, 132, 255, 0.28);
-        }
-
-        .mac-terminal {
-            background: var(--terminal-bg);
-            color: var(--terminal-text);
-            border-radius: 18px;
-            margin-top: 26px;
-            padding: 0 0 18px;
-            border: 1px solid rgba(255, 255, 255, 0.08);
-            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-            position: relative;
-            z-index: 2;
-        }
-
-        .mac-terminal-header {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            padding: 14px 18px;
-            border-bottom: 1px solid var(--terminal-divider);
-        }
-
-        .mac-terminal-header .traffic-light {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            display: inline-flex;
-        }
-
-        .traffic-red { background: #ff5f56; }
-        .traffic-yellow { background: #ffbd2e; }
-        .traffic-green { background: #27c93f; }
-
-        .mac-terminal-title {
-            margin-left: auto;
-            font-size: 0.8rem;
-            letter-spacing: 0.14em;
-            text-transform: uppercase;
-            opacity: 0.7;
-        }
-
-        .mac-terminal-body {
-            padding: 16px 18px 18px;
-            font-family: 'SFMono-Regular', SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-            font-size: 0.85rem;
-            line-height: 1.6;
-        }
-
-        .terminal-line {
-            display: flex;
-            align-items: baseline;
-            gap: 12px;
-            margin-bottom: 8px;
-            flex-wrap: wrap;
-            word-break: break-word;
-        }
-
-        .terminal-line:last-child {
-            margin-bottom: 0;
-        }
-
-        .prompt {
-            color: var(--terminal-prompt);
-        }
-
-        .terminal-divider {
-            height: 1px;
-            background: var(--terminal-divider);
-            margin: 12px 0 14px;
-        }
-
-        .status-row {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .status-dot {
-            width: 10px;
-            height: 10px;
-            border-radius: 50%;
-            background: var(--status-loading);
-            box-shadow: 0 0 12px rgba(10, 132, 255, 0.35);
-            transition: background 0.3s ease, box-shadow 0.3s ease;
-        }
-
-        .status-dot.playing {
-            background: var(--status-playing);
-            box-shadow: 0 0 12px rgba(48, 209, 88, 0.45);
-        }
-
-        .status-dot.paused {
-            background: var(--status-paused);
-            box-shadow: 0 0 12px rgba(255, 214, 10, 0.4);
-        }
-
-        .status-dot.loading {
-            background: var(--status-loading);
-            box-shadow: 0 0 12px rgba(10, 132, 255, 0.42);
-        }
-
-        .status-dot.error {
-            background: var(--status-error);
-            box-shadow: 0 0 12px rgba(255, 69, 58, 0.42);
-        }
-
-        #youtube-player {
-            position: absolute;
-            width: 1px;
-            height: 1px;
-            left: -9999px;
-            visibility: hidden;
-        }
-
-        @media (max-width: 480px) {
-            body {
-                padding: 22px 14px;
-            }
-
-            .container {
-                padding: 26px 22px;
-            }
-
-            .button-row {
-                grid-template-columns: 1fr;
-            }
-
-            .theme-toggle {
-                width: 100%;
-                justify-content: space-between;
-            }
-
-            .mac-terminal-body {
-                font-size: 0.8rem;
-            }
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <div class="container">
-        <div class="header">
-            <div class="logo">🎵 AudioTube</div>
-            <div class="subtitle">YouTube Music Player</div>
-        </div>
+        <header class="header">
+            <div class="logo" aria-hidden="true">
+                <svg class="logo-icon" viewBox="0 0 64 64" role="img">
+                    <defs>
+                        <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                            <stop offset="0%" stop-color="#0af" />
+                            <stop offset="50%" stop-color="#5f52ff" />
+                            <stop offset="100%" stop-color="#63e6e2" />
+                        </linearGradient>
+                        <linearGradient id="logoGlow" x1="0%" y1="0%" x2="100%" y2="100%">
+                            <stop offset="0%" stop-color="rgba(255,255,255,0.85)" />
+                            <stop offset="100%" stop-color="rgba(255,255,255,0.2)" />
+                        </linearGradient>
+                    </defs>
+                    <path d="M12 18c0-3.866 3.134-7 7-7h26c3.866 0 7 3.134 7 7v28c0 3.866-3.134 7-7 7H19c-3.866 0-7-3.134-7-7V18z" fill="url(#logoGradient)" opacity="0.9"/>
+                    <path d="M26 22c0-2.21 2.05-3.62 3.95-2.62l16 8.5c2 1.06 2 3.98 0 5.04l-16 8.5C28.05 42.42 26 41.01 26 38.8V22z" fill="url(#logoGlow)"/>
+                    <circle cx="20" cy="20" r="5" fill="rgba(255,255,255,0.45)"/>
+                    <circle cx="44" cy="44" r="4" fill="rgba(255,255,255,0.35)"/>
+                </svg>
+                <span class="logo-text">AudioTube</span>
+            </div>
+            <p class="subtitle">Liquid-glass YouTube audio streaming</p>
+        </header>
 
-        <div class="theme-toggle" role="group" aria-label="Pengaturan tema">
-            <button type="button" data-theme="light">☀️ Light</button>
-            <button type="button" data-theme="dark">🌙 Dark</button>
-            <button type="button" data-theme="auto" class="active">🖥 Auto</button>
+        <div class="theme-toggle" role="group" aria-label="Theme selector">
+            <button type="button" data-theme="light">
+                <span class="icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="5" fill="currentColor" stroke="none" opacity="0.25"/>
+                        <line x1="12" y1="2" x2="12" y2="5"/>
+                        <line x1="12" y1="19" x2="12" y2="22"/>
+                        <line x1="4.22" y1="4.22" x2="6.34" y2="6.34"/>
+                        <line x1="17.66" y1="17.66" x2="19.78" y2="19.78"/>
+                        <line x1="2" y1="12" x2="5" y2="12"/>
+                        <line x1="19" y1="12" x2="22" y2="12"/>
+                        <line x1="4.22" y1="19.78" x2="6.34" y2="17.66"/>
+                        <line x1="17.66" y1="6.34" x2="19.78" y2="4.22"/>
+                    </svg>
+                </span>
+                <span class="label">Light</span>
+            </button>
+            <button type="button" data-theme="dark">
+                <span class="icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M21 14.5A8.5 8.5 0 0 1 9.5 3a8.5 8.5 0 1 0 11.5 11.5Z" fill="currentColor" opacity="0.85"/>
+                    </svg>
+                </span>
+                <span class="label">Dark</span>
+            </button>
+            <button type="button" data-theme="auto" class="active">
+                <span class="icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M4 12a8 8 0 1 1 8 8" opacity="0.4"/>
+                        <path d="M12 4a8 8 0 0 1 0 16"/>
+                        <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none"/>
+                    </svg>
+                </span>
+                <span class="label">Auto</span>
+            </button>
         </div>
 
         <div class="input-section">
+            <label class="sr-only" for="yt-url">YouTube video link</label>
             <input
                 type="text"
                 id="yt-url"
                 class="url-input"
-                placeholder="Tempel tautan YouTube di sini..."
+                placeholder="Paste a YouTube link and start streaming…"
                 autocomplete="off"
             >
         </div>
 
-        <div class="error" id="error-message"></div>
+        <div class="error" id="error-message" role="alert"></div>
 
         <div class="button-row">
-            <button class="btn btn-primary" id="play-btn">▶ Putar</button>
-            <button class="btn btn-primary" id="paste-play-btn">⎘ Paste &amp; Play</button>
-            <button class="btn btn-secondary" id="clear-btn">🗑 Bersihkan</button>
+            <button class="btn btn-primary" id="play-btn">
+                <span class="icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24">
+                        <path d="M8 5v14l11-7z" fill="currentColor"/>
+                    </svg>
+                </span>
+                <span class="label">Play</span>
+            </button>
+            <button class="btn btn-primary" id="paste-play-btn">
+                <span class="icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M9 3h6l1 2h3a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h3z"/>
+                        <path d="M10 12.5v5l4-2.5z" fill="currentColor" stroke="none"/>
+                    </svg>
+                </span>
+                <span class="label">Paste &amp; Play</span>
+            </button>
+            <button class="btn btn-secondary" id="clear-btn">
+                <span class="icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M4 7h16"/>
+                        <path d="M10 11v6"/>
+                        <path d="M14 11v6"/>
+                        <path d="M6 7l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12"/>
+                        <path d="M9 7V4h6v3"/>
+                    </svg>
+                </span>
+                <span class="label">Reset</span>
+            </button>
         </div>
 
-        <div class="loading" id="loading">
-            <div class="spinner"></div>
-            <p>Menghubungkan audio…</p>
+        <div class="loading" id="loading" role="status">
+            <div class="spinner" aria-hidden="true"></div>
+            <p>Connecting to the audio stream…</p>
         </div>
 
-        <div class="player-card" id="player-card">
+        <section class="player-card" id="player-card" aria-live="polite">
             <div class="song-info">
-                <div class="song-title" id="song-title">AudioTube Player</div>
-                <div class="song-status" id="song-status">Siap diputar</div>
+                <h2 class="song-title" id="song-title">AudioTube Player</h2>
+                <p class="song-status" id="song-status">Ready to play</p>
             </div>
 
             <div class="progress-section">
@@ -640,19 +132,51 @@
                 </div>
                 <div class="progress-container" id="progress-container">
                     <div class="progress-bar" id="progress-bar"></div>
-                    <div class="progress-thumb" id="progress-thumb"></div>
+                    <div class="progress-thumb" id="progress-thumb" role="slider" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
                 </div>
             </div>
 
             <div class="main-controls">
-                <button class="control-btn" id="backward-btn" aria-label="Mundur 10 detik">⏪</button>
-                <button class="control-btn play-btn" id="play-pause-btn" aria-label="Putar / Jeda">⏸</button>
-                <button class="control-btn" id="forward-btn" aria-label="Maju 10 detik">⏩</button>
+                <button class="control-btn" id="backward-btn" aria-label="Rewind 10 seconds">
+                    <span class="icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M11 19 2 12l9-7v14z" fill="currentColor"/>
+                            <path d="M22 19l-9-7 9-7v14z" fill="currentColor" opacity="0.65"/>
+                        </svg>
+                    </span>
+                </button>
+                <button class="control-btn play-btn" id="play-pause-btn" aria-label="Play">
+                    <span class="icon icon-play" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M8 5v14l11-7z" fill="currentColor"/>
+                        </svg>
+                    </span>
+                    <span class="icon icon-pause" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M7 5h4v14H7z" fill="currentColor"/>
+                            <path d="M13 5h4v14h-4z" fill="currentColor"/>
+                        </svg>
+                    </span>
+                </button>
+                <button class="control-btn" id="forward-btn" aria-label="Forward 10 seconds">
+                    <span class="icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <path d="m13 5 9 7-9 7V5z" fill="currentColor"/>
+                            <path d="M2 5v14l9-7-9-7z" fill="currentColor" opacity="0.65"/>
+                        </svg>
+                    </span>
+                </button>
             </div>
 
             <div class="secondary-controls">
                 <div class="volume-control">
-                    <span class="volume-icon">🔊</span>
+                    <span class="volume-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M4 9v6h4l5 4V5l-5 4H4z" fill="currentColor" stroke="none"/>
+                            <path d="M16 9a3 3 0 0 1 0 6"/>
+                            <path d="M18.5 6.5a6.5 6.5 0 0 1 0 11"/>
+                        </svg>
+                    </span>
                     <input
                         type="range"
                         class="volume-slider"
@@ -663,11 +187,21 @@
                         aria-label="Volume"
                     >
                 </div>
-                <button class="loop-toggle" id="loop-btn">🔁 Loop</button>
+                <button class="loop-toggle" id="loop-btn" aria-pressed="false">
+                    <span class="icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 12a6 6 0 0 1 6-6h5"/>
+                            <path d="M21 12a6 6 0 0 1-6 6h-5"/>
+                            <path d="m15 4 3 3-3 3"/>
+                            <path d="m9 20-3-3 3-3"/>
+                        </svg>
+                    </span>
+                    <span class="label" data-default="Loop" data-active="Looping">Loop</span>
+                </button>
             </div>
-        </div>
+        </section>
 
-        <div class="mac-terminal" aria-live="polite">
+        <section class="mac-terminal" aria-live="polite">
             <div class="mac-terminal-header">
                 <span class="traffic-light traffic-red"></span>
                 <span class="traffic-light traffic-yellow"></span>
@@ -675,735 +209,24 @@
                 <span class="mac-terminal-title">Stream Monitor</span>
             </div>
             <div class="mac-terminal-body">
-                <div class="terminal-line"><span class="prompt">origin%</span><span id="terminal-origin">menunggu…</span></div>
-                <div class="terminal-line"><span class="prompt">iframe%</span><span id="terminal-iframe">belum tersedia</span></div>
+                <div class="terminal-line"><span class="prompt">origin%</span><span id="terminal-origin">waiting…</span></div>
+                <div class="terminal-line"><span class="prompt">iframe%</span><span id="terminal-iframe">not available yet</span></div>
                 <div class="terminal-divider"></div>
                 <div class="terminal-line status-row">
                     <span class="status-dot loading" id="terminal-status-dot"></span>
-                    <span id="terminal-status-text">Idle • siap menerima perintah</span>
+                    <span id="terminal-status-text">Idle • ready for commands</span>
                 </div>
-                <div class="terminal-line">🎧 Audio only mode disiapkan</div>
-                <div class="terminal-line">📱 Desain touch-first ala macOS &amp; iOS</div>
-                <div class="terminal-line">🔁 Loop &amp; background playback siap</div>
-                <div class="terminal-line">⏯ Slider dan kontrol bisa digeser &amp; disentuh</div>
+                <div class="terminal-line">Audio renderer armed for background playback</div>
+                <div class="terminal-line">Dynamic EQ tuned for pocket speakers</div>
+                <div class="terminal-line">Loop controller listening on channel 26G</div>
+                <div class="terminal-line">Gesture engine smoothed at 120Hz</div>
             </div>
-        </div>
+        </section>
     </div>
 
     <div id="youtube-player"></div>
 
     <script src="https://www.youtube.com/iframe_api"></script>
-    <script>
-        let player;
-        let isPlaying = false;
-        let isLooping = false;
-        let duration = 0;
-        let isDragging = false;
-        let updateInterval;
-        let pendingPlay = false;
-        let themePreference = 'auto';
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-
-        const allowedOrigin = null;
-        const themeStorageKey = 'audiotube-theme-preference';
-
-        const terminalOrigin = document.getElementById('terminal-origin');
-        const terminalIframe = document.getElementById('terminal-iframe');
-        const terminalStatusDot = document.getElementById('terminal-status-dot');
-        const terminalStatusText = document.getElementById('terminal-status-text');
-
-        const terminalStates = {
-            idle: { className: 'loading', message: 'Idle • siap menerima perintah' },
-            loading: { className: 'loading', message: 'Menghubungkan ke stream audio…' },
-            playing: { className: 'playing', message: 'Streaming stabil • kualitas ringan' },
-            paused: { className: 'paused', message: 'Dijeda — tekan ▶ untuk lanjut' },
-            buffering: { className: 'loading', message: 'Buffering… mengoptimalkan koneksi' },
-            error: { className: 'error', message: 'Terjadi gangguan koneksi stream' }
-        };
-
-        function updateTerminalInfo() {
-            const originToShow = (allowedOrigin && allowedOrigin.length) ? allowedOrigin : window.location.origin;
-            terminalOrigin.textContent = originToShow || 'local-preview';
-
-            if (player && player.getIframe) {
-                try {
-                    const iframe = player.getIframe();
-                    terminalIframe.textContent = iframe ? iframe.src : 'iframe belum siap';
-                } catch (err) {
-                    terminalIframe.textContent = 'gagal membaca iframe';
-                }
-            } else {
-                terminalIframe.textContent = 'iframe belum tersedia';
-            }
-        }
-
-        function setTerminalState(stateKey, customMessage) {
-            const state = terminalStates[stateKey] || terminalStates.idle;
-            terminalStatusDot.className = `status-dot ${state.className}`;
-            terminalStatusText.textContent = customMessage || state.message;
-        }
-
-        function showLoading(show) {
-            const loading = document.getElementById('loading');
-            loading.style.display = show ? 'block' : 'none';
-            if (show) {
-                setTerminalState('loading');
-            } else if (!isPlaying) {
-                setTerminalState('idle');
-            }
-        }
-
-        function showError(message) {
-            const errorBox = document.getElementById('error-message');
-            errorBox.textContent = message;
-            errorBox.style.display = 'block';
-            setTerminalState('error', message);
-        }
-
-        function clearError() {
-            const errorBox = document.getElementById('error-message');
-            errorBox.textContent = '';
-            errorBox.style.display = 'none';
-        }
-
-        function formatTime(seconds) {
-            seconds = Math.max(seconds, 0);
-            const minutes = Math.floor(seconds / 60);
-            const secs = Math.floor(seconds % 60);
-            return `${minutes}:${secs.toString().padStart(2, '0')}`;
-        }
-
-        function updatePlayPauseButton() {
-            const btn = document.getElementById('play-pause-btn');
-            btn.textContent = isPlaying ? '⏸' : '▶';
-        }
-
-        function renderProgress(percent) {
-            const clamped = Math.max(0, Math.min(100, percent));
-            document.getElementById('progress-bar').style.width = clamped + '%';
-            document.getElementById('progress-thumb').style.left = clamped + '%';
-        }
-
-        function updateProgress() {
-            if (!player || !duration || isDragging) return;
-            const currentTime = player.getCurrentTime();
-            const percent = (currentTime / duration) * 100;
-            renderProgress(percent);
-            document.getElementById('current-time').textContent = formatTime(currentTime);
-        }
-
-        function extractVideoID(url) {
-            if (!url) return null;
-            const regex = /(?:youtube\.com\/(?:shorts\/|watch\?v=|embed\/)|youtu\.be\/)([\w-]{11})/;
-            const match = url.match(regex);
-            if (match && match[1]) {
-                return match[1];
-            }
-            try {
-                const parsed = new URL(url);
-                if (parsed.hostname.includes('youtube.com')) {
-                    return parsed.searchParams.get('v');
-                }
-            } catch (err) {
-                return null;
-            }
-            return null;
-        }
-
-        function ensureIframePermissions() {
-            if (!player || !player.getIframe) return;
-            try {
-                const iframe = player.getIframe();
-                if (iframe) {
-                    iframe.setAttribute('allow', 'autoplay; encrypted-media; picture-in-picture');
-                    iframe.setAttribute('playsinline', '1');
-                }
-            } catch (err) {
-                console.warn('Tidak dapat mengatur atribut iframe:', err);
-            }
-        }
-
-        function applyMobileOptimizations() {
-            if (!player || typeof player.setPlaybackQuality !== 'function') return;
-            try {
-                player.setPlaybackQuality('small');
-                setTimeout(() => {
-                    if (player && typeof player.setPlaybackQuality === 'function') {
-                        player.setPlaybackQuality('tiny');
-                    }
-                }, 1500);
-            } catch (err) {
-                console.warn('Gagal mengatur kualitas playback:', err);
-            }
-        }
-
-        function updateMediaSession(title) {
-            if ('mediaSession' in navigator) {
-                try {
-                    navigator.mediaSession.metadata = new MediaMetadata({
-                        title: title || 'AudioTube Stream',
-                        artist: 'YouTube Audio',
-                        album: 'AudioTube',
-                        artwork: [
-                            { src: 'https://www.youtube.com/s/desktop/8e90062a/img/favicon_144.png', sizes: '144x144', type: 'image/png' }
-                        ]
-                    });
-
-                    navigator.mediaSession.setActionHandler('play', () => {
-                        if (!isPlaying) {
-                            togglePlayPause();
-                        }
-                    });
-                    navigator.mediaSession.setActionHandler('pause', () => {
-                        if (isPlaying) {
-                            togglePlayPause();
-                        }
-                    });
-                    navigator.mediaSession.setActionHandler('seekforward', () => seekForward());
-                    navigator.mediaSession.setActionHandler('seekbackward', () => seekBackward());
-                } catch (err) {
-                    console.warn('MediaSession tidak tersedia sepenuhnya:', err);
-                }
-            }
-        }
-
-        function updateMediaSessionState() {
-            if ('mediaSession' in navigator) {
-                navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused';
-            }
-        }
-
-        function safePlay(options = {}) {
-            if (!player || typeof player.playVideo !== 'function') return;
-
-            const {
-                terminalMessage,
-                songStatus,
-                showBlockNotice = true,
-                notifyOnBlock = false
-            } = options;
-
-            try {
-                const playResult = player.playVideo();
-                if (playResult && typeof playResult.then === 'function') {
-                    playResult.then(() => {
-                        isPlaying = true;
-                        pendingPlay = false;
-                        document.getElementById('song-status').textContent = songStatus || 'Sedang diputar…';
-                        updatePlayPauseButton();
-                        setTerminalState('playing', terminalMessage || terminalStates.playing.message);
-                        updateMediaSessionState();
-                    }).catch(err => {
-                        console.warn('Playback diblokir:', err);
-                        isPlaying = false;
-                        pendingPlay = true;
-                        updatePlayPauseButton();
-                        if (showBlockNotice) {
-                            setTerminalState('paused', 'Sentuh ▶ untuk mulai memutar audio');
-                            document.getElementById('song-status').textContent = 'Tap ▶ untuk memulai audio';
-                        }
-                        if (notifyOnBlock) {
-                            showError('Browser memblokir autoplay. Tap ▶ untuk mulai.');
-                        }
-                        updateMediaSessionState();
-                    });
-                } else {
-                    isPlaying = true;
-                    pendingPlay = false;
-                    document.getElementById('song-status').textContent = songStatus || 'Sedang diputar…';
-                    updatePlayPauseButton();
-                    setTerminalState('playing', terminalMessage || terminalStates.playing.message);
-                    updateMediaSessionState();
-                }
-            } catch (err) {
-                console.error('safePlay error:', err);
-                isPlaying = false;
-                pendingPlay = true;
-                updatePlayPauseButton();
-                if (showBlockNotice) {
-                    setTerminalState('error', 'Tidak bisa memulai pemutaran. Coba lagi.');
-                }
-                if (notifyOnBlock) {
-                    showError('Gagal memulai audio. Silakan coba lagi.');
-                }
-            }
-        }
-
-        function togglePlayPause() {
-            if (!player) return;
-            clearError();
-            if (isPlaying) {
-                player.pauseVideo();
-                pendingPlay = false;
-            } else {
-                pendingPlay = true;
-                safePlay({ terminalMessage: 'Melanjutkan pemutaran…' });
-            }
-        }
-
-        function seekBackward() {
-            if (!player) return;
-            const newTime = Math.max(0, player.getCurrentTime() - 10);
-            player.seekTo(newTime, true);
-            document.getElementById('current-time').textContent = formatTime(newTime);
-        }
-
-        function seekForward() {
-            if (!player) return;
-            const newTime = Math.min(duration || 0, player.getCurrentTime() + 10);
-            player.seekTo(newTime, true);
-            document.getElementById('current-time').textContent = formatTime(newTime);
-        }
-
-        function setVolume(volume) {
-            const vol = Math.max(0, Math.min(100, Number(volume)));
-            if (player && typeof player.setVolume === 'function') {
-                player.setVolume(vol);
-            }
-        }
-
-        function toggleLoop() {
-            isLooping = !isLooping;
-            const btn = document.getElementById('loop-btn');
-            if (isLooping) {
-                btn.classList.add('active');
-                btn.textContent = '🔁 Loop On';
-                setTerminalState('playing', 'Loop aktif — lagu akan terus diputar');
-            } else {
-                btn.classList.remove('active');
-                btn.textContent = '🔁 Loop';
-                setTerminalState(isPlaying ? 'playing' : 'idle');
-            }
-        }
-
-        function pasteAndPlay() {
-            const input = document.getElementById('yt-url');
-            if (!navigator.clipboard || !navigator.clipboard.readText) {
-                showError('Clipboard API tidak tersedia. Tempel secara manual.');
-                input.focus();
-                return;
-            }
-            navigator.clipboard.readText().then(text => {
-                if (!text || !text.trim()) {
-                    showError('Clipboard kosong.');
-                    input.focus();
-                    return;
-                }
-                input.value = text.trim();
-                pendingPlay = true;
-                loadAudio();
-            }).catch(err => {
-                console.warn('Clipboard read failed:', err);
-                showError('Tidak dapat membaca clipboard. Tempel secara manual.');
-                input.focus();
-            });
-        }
-
-        function clearAll() {
-            const input = document.getElementById('yt-url');
-            input.value = '';
-            input.focus();
-
-            if (player) {
-                player.destroy();
-                player = null;
-            }
-            if (updateInterval) {
-                clearInterval(updateInterval);
-                updateInterval = null;
-            }
-
-            isPlaying = false;
-            isLooping = false;
-            pendingPlay = false;
-            duration = 0;
-
-            document.getElementById('player-card').style.display = 'none';
-            document.getElementById('loop-btn').classList.remove('active');
-            document.getElementById('loop-btn').textContent = '🔁 Loop';
-            document.getElementById('song-status').textContent = 'Siap diputar';
-            document.getElementById('song-title').textContent = 'AudioTube Player';
-            document.getElementById('current-time').textContent = '0:00';
-            document.getElementById('total-time').textContent = '0:00';
-            renderProgress(0);
-            updatePlayPauseButton();
-            clearError();
-            setTerminalState('idle');
-            updateMediaSessionState();
-        }
-
-        function loadAudio() {
-            clearError();
-            const url = document.getElementById('yt-url').value.trim();
-
-            if (!url) {
-                showError('Silakan masukkan tautan YouTube terlebih dahulu.');
-                return;
-            }
-
-            const videoId = extractVideoID(url);
-            if (!videoId) {
-                showError('Tautan YouTube tidak valid. Periksa kembali formatnya.');
-                return;
-            }
-
-            showLoading(true);
-            setTerminalState('loading', 'Menginisialisasi player…');
-
-            if (player) {
-                player.destroy();
-                player = null;
-                if (updateInterval) {
-                    clearInterval(updateInterval);
-                    updateInterval = null;
-                }
-            }
-
-            pendingPlay = true;
-
-            player = new YT.Player('youtube-player', {
-                height: '1',
-                width: '1',
-                videoId: videoId,
-                playerVars: {
-                    autoplay: 1,
-                    playsinline: 1,
-                    controls: 0,
-                    disablekb: 1,
-                    fs: 0,
-                    rel: 0,
-                    modestbranding: 1,
-                    iv_load_policy: 3,
-                    origin: (allowedOrigin && allowedOrigin.length) ? allowedOrigin : window.location.origin
-                },
-                events: {
-                    'onReady': onPlayerReady,
-                    'onStateChange': onPlayerStateChange,
-                    'onError': onPlayerError
-                }
-            });
-
-            setTimeout(ensureIframePermissions, 600);
-            updateTerminalInfo();
-        }
-
-        function onPlayerReady() {
-            showLoading(false);
-            ensureIframePermissions();
-            applyMobileOptimizations();
-
-            duration = player.getDuration();
-            const title = player.getVideoData().title || 'YouTube Audio';
-
-            document.getElementById('song-title').textContent = title;
-            document.getElementById('total-time').textContent = formatTime(duration);
-            document.getElementById('song-status').textContent = 'Menyiapkan pemutaran…';
-            document.getElementById('player-card').style.display = 'block';
-
-            setVolume(document.getElementById('volume-slider').value);
-            updateMediaSession(title);
-            updateMediaSessionState();
-
-            if (updateInterval) {
-                clearInterval(updateInterval);
-            }
-            updateInterval = setInterval(updateProgress, 500);
-
-            safePlay({
-                terminalMessage: 'Streaming dimulai • mode ringan aktif',
-                songStatus: 'Sedang diputar…',
-                notifyOnBlock: true
-            });
-            updateTerminalInfo();
-        }
-
-        function onPlayerStateChange(event) {
-            const status = document.getElementById('song-status');
-
-            switch (event.data) {
-                case YT.PlayerState.PLAYING:
-                    status.textContent = 'Sedang diputar…';
-                    isPlaying = true;
-                    pendingPlay = false;
-                    setTerminalState('playing', 'Streaming stabil • kualitas ringan');
-                    updateMediaSessionState();
-                    break;
-                case YT.PlayerState.PAUSED:
-                    status.textContent = 'Dijeda';
-                    isPlaying = false;
-                    pendingPlay = false;
-                    setTerminalState('paused');
-                    updateMediaSessionState();
-                    break;
-                case YT.PlayerState.BUFFERING:
-                    status.textContent = 'Buffering…';
-                    pendingPlay = true;
-                    setTerminalState('buffering');
-                    applyMobileOptimizations();
-                    break;
-                case YT.PlayerState.ENDED:
-                    if (isLooping) {
-                        player.seekTo(0, true);
-                        pendingPlay = true;
-                        safePlay({ terminalMessage: 'Loop aktif', showBlockNotice: false });
-                        status.textContent = 'Looping…';
-                    } else {
-                        status.textContent = 'Pemutaran selesai';
-                        isPlaying = false;
-                        pendingPlay = false;
-                        setTerminalState('paused', 'Pemutaran selesai');
-                        updateMediaSessionState();
-                    }
-                    break;
-                case YT.PlayerState.CUED:
-                    status.textContent = 'Siap diputar';
-                    isPlaying = false;
-                    setTerminalState('idle');
-                    break;
-            }
-            updatePlayPauseButton();
-        }
-
-        function onPlayerError(event) {
-            showLoading(false);
-            isPlaying = false;
-            pendingPlay = false;
-            updatePlayPauseButton();
-            updateMediaSessionState();
-
-            let errorMessage = 'Terjadi kesalahan saat memuat audio. ';
-            switch (event.data) {
-                case 2:
-                    errorMessage += 'ID video tidak valid.';
-                    break;
-                case 5:
-                    errorMessage += 'Video tidak bisa diputar di HTML5 player.';
-                    break;
-                case 100:
-                    errorMessage += 'Video tidak ditemukan atau sudah dihapus.';
-                    break;
-                case 101:
-                case 150:
-                    errorMessage += 'Pemilik video membatasi pemutaran.';
-                    break;
-                default:
-                    errorMessage += 'Silakan coba lagi.';
-            }
-            showError(errorMessage);
-        }
-
-        function initProgressBar() {
-            const container = document.getElementById('progress-container');
-            const thumb = document.getElementById('progress-thumb');
-            let activePointerId = null;
-
-            function getClientX(event) {
-                if (event.touches && event.touches.length) return event.touches[0].clientX;
-                if (event.changedTouches && event.changedTouches.length) return event.changedTouches[0].clientX;
-                return event.clientX;
-            }
-
-            function getPercentFromClientX(clientX) {
-                const rect = container.getBoundingClientRect();
-                const x = clientX - rect.left;
-                return Math.max(0, Math.min(100, (x / rect.width) * 100));
-            }
-
-            function updateDuringDrag(percent) {
-                renderProgress(percent);
-                if (duration) {
-                    document.getElementById('current-time').textContent = formatTime((percent / 100) * duration);
-                }
-            }
-
-            function commitSeek(percent) {
-                if (player && duration) {
-                    player.seekTo((percent / 100) * duration, true);
-                }
-            }
-
-            if (window.PointerEvent) {
-                thumb.addEventListener('pointerdown', e => {
-                    activePointerId = e.pointerId;
-                    isDragging = true;
-                    updateDuringDrag(getPercentFromClientX(getClientX(e)));
-                    e.preventDefault();
-                });
-
-                container.addEventListener('pointerdown', e => {
-                    if (e.target === thumb) return;
-                    activePointerId = e.pointerId;
-                    const percent = getPercentFromClientX(getClientX(e));
-                    updateDuringDrag(percent);
-                    commitSeek(percent);
-                    isDragging = true;
-                    e.preventDefault();
-                });
-
-                window.addEventListener('pointermove', e => {
-                    if (!isDragging || (activePointerId !== null && e.pointerId !== activePointerId)) return;
-                    updateDuringDrag(getPercentFromClientX(getClientX(e)));
-                });
-
-                const finishPointer = e => {
-                    if (!isDragging || (activePointerId !== null && e.pointerId !== activePointerId)) return;
-                    const percent = getPercentFromClientX(getClientX(e));
-                    updateDuringDrag(percent);
-                    commitSeek(percent);
-                    isDragging = false;
-                    activePointerId = null;
-                };
-
-                window.addEventListener('pointerup', finishPointer);
-                window.addEventListener('pointercancel', finishPointer);
-            } else {
-                thumb.addEventListener('touchstart', e => {
-                    isDragging = true;
-                    updateDuringDrag(getPercentFromClientX(getClientX(e)));
-                    e.preventDefault();
-                }, { passive: false });
-
-                thumb.addEventListener('touchmove', e => {
-                    if (!isDragging) return;
-                    updateDuringDrag(getPercentFromClientX(getClientX(e)));
-                    e.preventDefault();
-                }, { passive: false });
-
-                thumb.addEventListener('touchend', e => {
-                    if (!isDragging) return;
-                    const percent = getPercentFromClientX(getClientX(e));
-                    updateDuringDrag(percent);
-                    commitSeek(percent);
-                    isDragging = false;
-                });
-
-                container.addEventListener('touchstart', e => {
-                    if (e.target === thumb) return;
-                    const percent = getPercentFromClientX(getClientX(e));
-                    updateDuringDrag(percent);
-                    commitSeek(percent);
-                }, { passive: true });
-
-                thumb.addEventListener('mousedown', e => {
-                    isDragging = true;
-                    updateDuringDrag(getPercentFromClientX(getClientX(e)));
-                    e.preventDefault();
-                });
-
-                window.addEventListener('mousemove', e => {
-                    if (!isDragging) return;
-                    updateDuringDrag(getPercentFromClientX(getClientX(e)));
-                });
-
-                window.addEventListener('mouseup', e => {
-                    if (!isDragging) return;
-                    const percent = getPercentFromClientX(getClientX(e));
-                    updateDuringDrag(percent);
-                    commitSeek(percent);
-                    isDragging = false;
-                });
-            }
-        }
-
-        function handleResumeGesture() {
-            if (pendingPlay && player && !isPlaying) {
-                safePlay({ terminalMessage: 'Melanjutkan setelah interaksi pengguna', showBlockNotice: false });
-            }
-        }
-
-        function handleVisibilityChange() {
-            if (!player) return;
-            if (document.visibilityState === 'visible') {
-                if (pendingPlay) {
-                    safePlay({ terminalMessage: 'Melanjutkan setelah kembali', showBlockNotice: false });
-                } else if (isPlaying) {
-                    safePlay({ terminalMessage: 'Menjaga playback tetap hidup', showBlockNotice: false });
-                }
-            } else if (document.visibilityState === 'hidden' && isPlaying) {
-                safePlay({ terminalMessage: 'Menjaga playback di latar belakang', showBlockNotice: false });
-            }
-        }
-
-        function applyTheme(preference, { save = true } = {}) {
-            themePreference = preference;
-            if (save) {
-                try {
-                    localStorage.setItem(themeStorageKey, preference);
-                } catch (err) {
-                    console.warn('Tidak bisa menyimpan preferensi tema:', err);
-                }
-            }
-            const resolved = preference === 'auto' ? (prefersDark.matches ? 'dark' : 'light') : preference;
-            document.body.setAttribute('data-theme', resolved);
-            document.querySelectorAll('.theme-toggle button').forEach(btn => {
-                btn.classList.toggle('active', btn.dataset.theme === preference);
-            });
-        }
-
-        function initTheme() {
-            let stored;
-            try {
-                stored = localStorage.getItem(themeStorageKey);
-            } catch (err) {
-                stored = null;
-            }
-            if (stored && ['light', 'dark', 'auto'].includes(stored)) {
-                applyTheme(stored, { save: false });
-            } else {
-                applyTheme('auto', { save: false });
-            }
-        }
-
-        function onYouTubeIframeAPIReady() {
-            console.log('YouTube API siap digunakan');
-        }
-
-        window.addEventListener('load', () => {
-            initTheme();
-            updateTerminalInfo();
-            initProgressBar();
-            setTerminalState('idle');
-
-            document.getElementById('yt-url').focus();
-            document.getElementById('play-btn').addEventListener('click', loadAudio);
-            document.getElementById('paste-play-btn').addEventListener('click', pasteAndPlay);
-            document.getElementById('clear-btn').addEventListener('click', clearAll);
-            document.getElementById('yt-url').addEventListener('keypress', e => {
-                if (e.key === 'Enter') {
-                    loadAudio();
-                }
-            });
-            document.getElementById('volume-slider').addEventListener('input', e => setVolume(e.target.value));
-            document.getElementById('loop-btn').addEventListener('click', toggleLoop);
-            document.getElementById('backward-btn').addEventListener('click', seekBackward);
-            document.getElementById('forward-btn').addEventListener('click', seekForward);
-            document.getElementById('play-pause-btn').addEventListener('click', togglePlayPause);
-            document.querySelectorAll('.theme-toggle button').forEach(btn => {
-                btn.addEventListener('click', () => applyTheme(btn.dataset.theme));
-            });
-        });
-
-        setInterval(updateTerminalInfo, 2500);
-        window.addEventListener('resize', updateTerminalInfo);
-        prefersDark.addEventListener('change', () => {
-            if (themePreference === 'auto') {
-                applyTheme('auto', { save: false });
-            }
-        });
-
-        document.addEventListener('visibilitychange', handleVisibilityChange);
-        window.addEventListener('pageshow', event => {
-            if (event.persisted && (isPlaying || pendingPlay) && player) {
-                safePlay({ terminalMessage: 'Melanjutkan setelah kembali', showBlockNotice: false });
-            }
-        });
-        window.addEventListener('focus', () => {
-            if (isPlaying && player) {
-                safePlay({ terminalMessage: 'Menjaga playback aktif', showBlockNotice: false });
-            }
-        });
-        document.addEventListener('click', handleResumeGesture);
-        document.addEventListener('touchend', handleResumeGesture, { passive: true });
-    </script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,781 @@
+let player;
+let isPlaying = false;
+let isLooping = false;
+let duration = 0;
+let isDragging = false;
+let updateInterval;
+let pendingPlay = false;
+let themePreference = 'auto';
+let bufferingRetry;
+let awaitingUnmute = false;
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
+const allowedOrigin = null;
+const themeStorageKey = 'audiotube-theme-preference';
+
+const terminalOrigin = document.getElementById('terminal-origin');
+const terminalIframe = document.getElementById('terminal-iframe');
+const terminalStatusDot = document.getElementById('terminal-status-dot');
+const terminalStatusText = document.getElementById('terminal-status-text');
+
+const terminalStates = {
+    idle: { className: 'loading', message: 'Idle • ready for commands' },
+    loading: { className: 'loading', message: 'Linking to the audio stream…' },
+    playing: { className: 'playing', message: 'Streaming steady • lightweight mode' },
+    paused: { className: 'paused', message: 'Paused — press Play to resume' },
+    buffering: { className: 'loading', message: 'Buffering… optimizing connection' },
+    error: { className: 'error', message: 'Stream connection interrupted' }
+};
+
+function updateTerminalInfo() {
+    const originToShow = (allowedOrigin && allowedOrigin.length) ? allowedOrigin : window.location.origin;
+    terminalOrigin.textContent = originToShow || 'local-preview';
+
+    if (player && player.getIframe) {
+        try {
+            const iframe = player.getIframe();
+            terminalIframe.textContent = iframe ? iframe.src : 'iframe pending';
+        } catch (err) {
+            terminalIframe.textContent = 'iframe not readable';
+        }
+    } else {
+        terminalIframe.textContent = 'not available yet';
+    }
+}
+
+function setTerminalState(stateKey, customMessage) {
+    const state = terminalStates[stateKey] || terminalStates.idle;
+    terminalStatusDot.className = `status-dot ${state.className}`;
+    terminalStatusText.textContent = customMessage || state.message;
+}
+
+function showLoading(show) {
+    const loading = document.getElementById('loading');
+    loading.style.display = show ? 'block' : 'none';
+    if (show) {
+        setTerminalState('loading');
+    } else if (!isPlaying) {
+        setTerminalState('idle');
+    }
+}
+
+function showError(message) {
+    const errorBox = document.getElementById('error-message');
+    errorBox.textContent = message;
+    errorBox.style.display = 'block';
+    setTerminalState('error', message);
+}
+
+function clearError() {
+    const errorBox = document.getElementById('error-message');
+    errorBox.textContent = '';
+    errorBox.style.display = 'none';
+}
+
+function formatTime(seconds) {
+    seconds = Math.max(seconds, 0);
+    const minutes = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+}
+
+function updatePlayPauseButton() {
+    const btn = document.getElementById('play-pause-btn');
+    btn.classList.toggle('is-playing', isPlaying);
+    btn.setAttribute('aria-label', isPlaying ? 'Pause' : 'Play');
+}
+
+function renderProgress(percent) {
+    const clamped = Math.max(0, Math.min(100, percent));
+    document.getElementById('progress-bar').style.width = clamped + '%';
+    const thumb = document.getElementById('progress-thumb');
+    thumb.style.left = clamped + '%';
+    thumb.setAttribute('aria-valuenow', clamped.toFixed(0));
+}
+
+function updateProgress() {
+    if (!player || !duration || isDragging) return;
+    const currentTime = player.getCurrentTime();
+    const percent = (currentTime / duration) * 100;
+    renderProgress(percent);
+    document.getElementById('current-time').textContent = formatTime(currentTime);
+}
+
+function extractVideoID(url) {
+    if (!url) return null;
+    const regex = /(?:youtube\.com\/(?:shorts\/|watch\?v=|embed\/)|youtu\.be\/)([\w-]{11})/;
+    const match = url.match(regex);
+    if (match && match[1]) {
+        return match[1];
+    }
+    try {
+        const parsed = new URL(url);
+        if (parsed.hostname.includes('youtube.com')) {
+            return parsed.searchParams.get('v');
+        }
+    } catch (err) {
+        return null;
+    }
+    return null;
+}
+
+function ensureIframePermissions() {
+    if (!player || !player.getIframe) return;
+    try {
+        const iframe = player.getIframe();
+        if (iframe) {
+            iframe.setAttribute('allow', 'autoplay; encrypted-media; picture-in-picture');
+            iframe.setAttribute('playsinline', '1');
+        }
+    } catch (err) {
+        console.warn('Unable to configure iframe attributes:', err);
+    }
+}
+
+function applyMobileOptimizations() {
+    if (!player || typeof player.setPlaybackQuality !== 'function') return;
+    try {
+        player.setPlaybackQuality('small');
+        setTimeout(() => {
+            if (player && typeof player.setPlaybackQuality === 'function') {
+                player.setPlaybackQuality('tiny');
+            }
+        }, 1200);
+    } catch (err) {
+        console.warn('Failed to set playback quality:', err);
+    }
+}
+
+function updateMediaSession(title) {
+    if ('mediaSession' in navigator) {
+        try {
+            navigator.mediaSession.metadata = new MediaMetadata({
+                title: title || 'AudioTube Stream',
+                artist: 'YouTube Audio',
+                album: 'AudioTube',
+                artwork: [
+                    { src: 'https://www.youtube.com/s/desktop/8e90062a/img/favicon_144.png', sizes: '144x144', type: 'image/png' }
+                ]
+            });
+
+            navigator.mediaSession.setActionHandler('play', () => {
+                if (!isPlaying) {
+                    togglePlayPause();
+                }
+            });
+            navigator.mediaSession.setActionHandler('pause', () => {
+                if (isPlaying) {
+                    togglePlayPause();
+                }
+            });
+            navigator.mediaSession.setActionHandler('seekforward', () => seekForward());
+            navigator.mediaSession.setActionHandler('seekbackward', () => seekBackward());
+        } catch (err) {
+            console.warn('MediaSession API limitation:', err);
+        }
+    }
+}
+
+function updateMediaSessionState() {
+    if ('mediaSession' in navigator) {
+        navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused';
+    }
+}
+
+function safePlay(options = {}) {
+    if (!player || typeof player.playVideo !== 'function') return;
+
+    const {
+        terminalMessage,
+        songStatus,
+        showBlockNotice = true,
+        notifyOnBlock = false
+    } = options;
+
+    try {
+        const playResult = player.playVideo();
+        if (playResult && typeof playResult.then === 'function') {
+            playResult.then(() => {
+                isPlaying = true;
+                pendingPlay = false;
+                document.getElementById('song-status').textContent = songStatus || 'Playing…';
+                updatePlayPauseButton();
+                setTerminalState('playing', terminalMessage || terminalStates.playing.message);
+                updateMediaSessionState();
+            }).catch(err => {
+                console.warn('Playback blocked:', err);
+                isPlaying = false;
+                pendingPlay = true;
+                updatePlayPauseButton();
+                if (showBlockNotice) {
+                    setTerminalState('paused', 'Tap Play to start audio');
+                    document.getElementById('song-status').textContent = 'Tap Play to start audio';
+                }
+                if (notifyOnBlock) {
+                    showError('Autoplay was blocked by the browser. Tap Play to continue.');
+                }
+                updateMediaSessionState();
+            });
+        } else {
+            isPlaying = true;
+            pendingPlay = false;
+            document.getElementById('song-status').textContent = songStatus || 'Playing…';
+            updatePlayPauseButton();
+            setTerminalState('playing', terminalMessage || terminalStates.playing.message);
+            updateMediaSessionState();
+        }
+    } catch (err) {
+        console.error('safePlay error:', err);
+        isPlaying = false;
+        pendingPlay = true;
+        updatePlayPauseButton();
+        if (showBlockNotice) {
+            setTerminalState('error', 'Unable to start playback. Try again.');
+        }
+        if (notifyOnBlock) {
+            showError('Could not start audio playback. Please try again.');
+        }
+    }
+}
+
+function togglePlayPause() {
+    if (!player) return;
+    clearError();
+    if (isPlaying) {
+        player.pauseVideo();
+        pendingPlay = false;
+    } else {
+        pendingPlay = true;
+        if (awaitingUnmute) {
+            try {
+                player.unMute();
+                awaitingUnmute = false;
+            } catch (err) {
+                console.warn('Unable to unmute before playing:', err);
+            }
+        }
+        safePlay({ terminalMessage: 'Resuming playback…' });
+    }
+}
+
+function seekBackward() {
+    if (!player) return;
+    const newTime = Math.max(0, player.getCurrentTime() - 10);
+    player.seekTo(newTime, true);
+    document.getElementById('current-time').textContent = formatTime(newTime);
+}
+
+function seekForward() {
+    if (!player) return;
+    const newTime = Math.min(duration || 0, player.getCurrentTime() + 10);
+    player.seekTo(newTime, true);
+    document.getElementById('current-time').textContent = formatTime(newTime);
+}
+
+function setVolume(volume) {
+    const vol = Math.max(0, Math.min(100, Number(volume)));
+    if (player && typeof player.setVolume === 'function') {
+        player.setVolume(vol);
+        if (vol > 0) {
+            try {
+                player.unMute();
+                awaitingUnmute = false;
+            } catch (err) {
+                console.warn('Unable to unmute when setting volume:', err);
+            }
+        }
+    }
+}
+
+function toggleLoop() {
+    isLooping = !isLooping;
+    const btn = document.getElementById('loop-btn');
+    const label = btn.querySelector('.label');
+    btn.classList.toggle('active', isLooping);
+    btn.setAttribute('aria-pressed', isLooping ? 'true' : 'false');
+    label.textContent = isLooping ? label.dataset.active : label.dataset.default;
+    setTerminalState(isLooping ? 'playing' : (isPlaying ? 'playing' : 'idle'), isLooping ? 'Loop enabled — track will repeat' : undefined);
+}
+
+function pasteAndPlay() {
+    const input = document.getElementById('yt-url');
+    if (!navigator.clipboard || !navigator.clipboard.readText) {
+        showError('Clipboard API is not available. Paste manually.');
+        input.focus();
+        return;
+    }
+    navigator.clipboard.readText().then(text => {
+        if (!text || !text.trim()) {
+            showError('Clipboard is empty.');
+            input.focus();
+            return;
+        }
+        input.value = text.trim();
+        pendingPlay = true;
+        loadAudio();
+    }).catch(err => {
+        console.warn('Clipboard read failed:', err);
+        showError('Unable to read from clipboard. Paste manually.');
+        input.focus();
+    });
+}
+
+function clearAll() {
+    const input = document.getElementById('yt-url');
+    input.value = '';
+    input.focus();
+
+    if (player) {
+        player.destroy();
+        player = null;
+    }
+    if (updateInterval) {
+        clearInterval(updateInterval);
+        updateInterval = null;
+    }
+    if (bufferingRetry) {
+        clearTimeout(bufferingRetry);
+        bufferingRetry = null;
+    }
+
+    isPlaying = false;
+    isLooping = false;
+    pendingPlay = false;
+    duration = 0;
+    awaitingUnmute = false;
+
+    document.getElementById('player-card').style.display = 'none';
+    const loopBtn = document.getElementById('loop-btn');
+    loopBtn.classList.remove('active');
+    loopBtn.setAttribute('aria-pressed', 'false');
+    const loopLabel = loopBtn.querySelector('.label');
+    loopLabel.textContent = loopLabel.dataset.default;
+    document.getElementById('song-status').textContent = 'Ready to play';
+    document.getElementById('song-title').textContent = 'AudioTube Player';
+    document.getElementById('current-time').textContent = '0:00';
+    document.getElementById('total-time').textContent = '0:00';
+    renderProgress(0);
+    updatePlayPauseButton();
+    clearError();
+    setTerminalState('idle');
+    updateMediaSessionState();
+}
+
+function loadAudio() {
+    clearError();
+    const url = document.getElementById('yt-url').value.trim();
+
+    if (!url) {
+        showError('Please provide a YouTube link first.');
+        return;
+    }
+
+    const videoId = extractVideoID(url);
+    if (!videoId) {
+        showError('That does not look like a valid YouTube link.');
+        return;
+    }
+
+    showLoading(true);
+    setTerminalState('loading', 'Initializing player…');
+
+    if (player) {
+        player.destroy();
+        player = null;
+        if (updateInterval) {
+            clearInterval(updateInterval);
+            updateInterval = null;
+        }
+        if (bufferingRetry) {
+            clearTimeout(bufferingRetry);
+            bufferingRetry = null;
+        }
+    }
+
+    pendingPlay = true;
+    awaitingUnmute = isMobile;
+
+    player = new YT.Player('youtube-player', {
+        height: '1',
+        width: '1',
+        videoId: videoId,
+        playerVars: {
+            autoplay: 1,
+            playsinline: 1,
+            controls: 0,
+            disablekb: 1,
+            fs: 0,
+            rel: 0,
+            modestbranding: 1,
+            iv_load_policy: 3,
+            origin: (allowedOrigin && allowedOrigin.length) ? allowedOrigin : window.location.origin
+        },
+        events: {
+            'onReady': onPlayerReady,
+            'onStateChange': onPlayerStateChange,
+            'onError': onPlayerError
+        }
+    });
+
+    setTimeout(ensureIframePermissions, 600);
+    updateTerminalInfo();
+}
+
+function onPlayerReady() {
+    showLoading(false);
+    ensureIframePermissions();
+    applyMobileOptimizations();
+
+    duration = player.getDuration();
+    const title = player.getVideoData().title || 'YouTube Audio';
+
+    document.getElementById('song-title').textContent = title;
+    document.getElementById('total-time').textContent = formatTime(duration);
+    document.getElementById('song-status').textContent = 'Priming playback…';
+    document.getElementById('player-card').style.display = 'block';
+
+    if (isMobile) {
+        try {
+            player.mute();
+        } catch (err) {
+            console.warn('Unable to mute on mobile init:', err);
+        }
+    }
+
+    setVolume(document.getElementById('volume-slider').value);
+    updateMediaSession(title);
+    updateMediaSessionState();
+
+    if (updateInterval) {
+        clearInterval(updateInterval);
+    }
+    updateInterval = setInterval(updateProgress, 500);
+
+    safePlay({
+        terminalMessage: 'Stream initiated • mobile friendly mode',
+        songStatus: 'Playing…',
+        notifyOnBlock: true
+    });
+    updateTerminalInfo();
+}
+
+function onPlayerStateChange(event) {
+    const status = document.getElementById('song-status');
+
+    switch (event.data) {
+        case YT.PlayerState.PLAYING:
+            status.textContent = 'Playing…';
+            isPlaying = true;
+            pendingPlay = false;
+            awaitingUnmute = false;
+            setTerminalState('playing', 'Streaming steady • lightweight mode');
+            updateMediaSessionState();
+            if (bufferingRetry) {
+                clearTimeout(bufferingRetry);
+                bufferingRetry = null;
+            }
+            break;
+        case YT.PlayerState.PAUSED:
+            status.textContent = 'Paused';
+            isPlaying = false;
+            pendingPlay = false;
+            setTerminalState('paused');
+            updateMediaSessionState();
+            break;
+        case YT.PlayerState.BUFFERING:
+            status.textContent = 'Buffering…';
+            pendingPlay = true;
+            setTerminalState('buffering');
+            applyMobileOptimizations();
+            if (bufferingRetry) {
+                clearTimeout(bufferingRetry);
+            }
+            if (isMobile) {
+                bufferingRetry = setTimeout(() => {
+                    if (!player) return;
+                    const state = player.getPlayerState();
+                    if (state === YT.PlayerState.BUFFERING) {
+                        try {
+                            player.setPlaybackQuality('tiny');
+                        } catch (err) {
+                            console.warn('Unable to downgrade quality:', err);
+                        }
+                        safePlay({ terminalMessage: 'Re-stabilizing mobile stream…', showBlockNotice: false });
+                    }
+                }, 1800);
+            }
+            break;
+        case YT.PlayerState.ENDED:
+            if (isLooping) {
+                player.seekTo(0, true);
+                pendingPlay = true;
+                safePlay({ terminalMessage: 'Loop active', showBlockNotice: false });
+                status.textContent = 'Looping…';
+            } else {
+                status.textContent = 'Playback finished';
+                isPlaying = false;
+                pendingPlay = false;
+                setTerminalState('paused', 'Playback finished');
+                updateMediaSessionState();
+            }
+            break;
+        case YT.PlayerState.CUED:
+            status.textContent = 'Ready to play';
+            isPlaying = false;
+            setTerminalState('idle');
+            break;
+        default:
+            break;
+    }
+    updatePlayPauseButton();
+}
+
+function onPlayerError(event) {
+    showLoading(false);
+    isPlaying = false;
+    pendingPlay = false;
+    updatePlayPauseButton();
+    updateMediaSessionState();
+
+    let errorMessage = 'Something went wrong while loading the audio. ';
+    switch (event.data) {
+        case 2:
+            errorMessage += 'The video ID is invalid.';
+            break;
+        case 5:
+            errorMessage += 'The video cannot play in the HTML5 player.';
+            break;
+        case 100:
+            errorMessage += 'The video was not found or was removed.';
+            break;
+        case 101:
+        case 150:
+            errorMessage += 'The video owner restricted playback.';
+            break;
+        default:
+            errorMessage += 'Please try again.';
+    }
+    showError(errorMessage);
+}
+
+function initProgressBar() {
+    const container = document.getElementById('progress-container');
+    const thumb = document.getElementById('progress-thumb');
+    let activePointerId = null;
+
+    function getClientX(event) {
+        if (event.touches && event.touches.length) return event.touches[0].clientX;
+        if (event.changedTouches && event.changedTouches.length) return event.changedTouches[0].clientX;
+        return event.clientX;
+    }
+
+    function getPercentFromClientX(clientX) {
+        const rect = container.getBoundingClientRect();
+        const x = clientX - rect.left;
+        return Math.max(0, Math.min(100, (x / rect.width) * 100));
+    }
+
+    function updateDuringDrag(percent) {
+        renderProgress(percent);
+        if (duration) {
+            document.getElementById('current-time').textContent = formatTime((percent / 100) * duration);
+        }
+    }
+
+    function commitSeek(percent) {
+        if (player && duration) {
+            player.seekTo((percent / 100) * duration, true);
+        }
+    }
+
+    if (window.PointerEvent) {
+        thumb.addEventListener('pointerdown', e => {
+            activePointerId = e.pointerId;
+            isDragging = true;
+            updateDuringDrag(getPercentFromClientX(getClientX(e)));
+            e.preventDefault();
+        });
+
+        container.addEventListener('pointerdown', e => {
+            if (e.target === thumb) return;
+            activePointerId = e.pointerId;
+            const percent = getPercentFromClientX(getClientX(e));
+            updateDuringDrag(percent);
+            commitSeek(percent);
+            isDragging = true;
+            e.preventDefault();
+        });
+
+        window.addEventListener('pointermove', e => {
+            if (!isDragging || (activePointerId !== null && e.pointerId !== activePointerId)) return;
+            updateDuringDrag(getPercentFromClientX(getClientX(e)));
+        });
+
+        const finishPointer = e => {
+            if (!isDragging || (activePointerId !== null && e.pointerId !== activePointerId)) return;
+            const percent = getPercentFromClientX(getClientX(e));
+            updateDuringDrag(percent);
+            commitSeek(percent);
+            isDragging = false;
+            activePointerId = null;
+        };
+
+        window.addEventListener('pointerup', finishPointer);
+        window.addEventListener('pointercancel', finishPointer);
+    } else {
+        thumb.addEventListener('touchstart', e => {
+            isDragging = true;
+            updateDuringDrag(getPercentFromClientX(getClientX(e)));
+            e.preventDefault();
+        }, { passive: false });
+
+        thumb.addEventListener('touchmove', e => {
+            if (!isDragging) return;
+            updateDuringDrag(getPercentFromClientX(getClientX(e)));
+            e.preventDefault();
+        }, { passive: false });
+
+        thumb.addEventListener('touchend', e => {
+            if (!isDragging) return;
+            const percent = getPercentFromClientX(getClientX(e));
+            updateDuringDrag(percent);
+            commitSeek(percent);
+            isDragging = false;
+        });
+
+        container.addEventListener('touchstart', e => {
+            if (e.target === thumb) return;
+            const percent = getPercentFromClientX(getClientX(e));
+            updateDuringDrag(percent);
+            commitSeek(percent);
+        }, { passive: true });
+
+        thumb.addEventListener('mousedown', e => {
+            isDragging = true;
+            updateDuringDrag(getPercentFromClientX(getClientX(e)));
+            e.preventDefault();
+        });
+
+        window.addEventListener('mousemove', e => {
+            if (!isDragging) return;
+            updateDuringDrag(getPercentFromClientX(getClientX(e)));
+        });
+
+        window.addEventListener('mouseup', e => {
+            if (!isDragging) return;
+            const percent = getPercentFromClientX(getClientX(e));
+            updateDuringDrag(percent);
+            commitSeek(percent);
+            isDragging = false;
+        });
+    }
+}
+
+function handleResumeGesture() {
+    if (pendingPlay && player && !isPlaying) {
+        if (awaitingUnmute) {
+            try {
+                player.unMute();
+            } catch (err) {
+                console.warn('Unable to unmute on resume gesture:', err);
+            }
+            awaitingUnmute = false;
+        }
+        safePlay({ terminalMessage: 'Resuming after user interaction', showBlockNotice: false });
+    }
+}
+
+function handleVisibilityChange() {
+    if (!player) return;
+    if (document.visibilityState === 'visible') {
+        if (pendingPlay) {
+            safePlay({ terminalMessage: 'Resuming after returning', showBlockNotice: false });
+        } else if (isPlaying) {
+            safePlay({ terminalMessage: 'Keeping playback alive', showBlockNotice: false });
+        }
+    } else if (document.visibilityState === 'hidden' && isPlaying) {
+        safePlay({ terminalMessage: 'Maintaining background playback', showBlockNotice: false });
+    }
+}
+
+function applyTheme(preference, { save = true } = {}) {
+    themePreference = preference;
+    if (save) {
+        try {
+            localStorage.setItem(themeStorageKey, preference);
+        } catch (err) {
+            console.warn('Unable to store theme preference:', err);
+        }
+    }
+    const resolved = preference === 'auto' ? (prefersDark.matches ? 'dark' : 'light') : preference;
+    document.body.setAttribute('data-theme', resolved);
+    document.querySelectorAll('.theme-toggle button').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.theme === preference);
+    });
+}
+
+function initTheme() {
+    let stored;
+    try {
+        stored = localStorage.getItem(themeStorageKey);
+    } catch (err) {
+        stored = null;
+    }
+    if (stored && ['light', 'dark', 'auto'].includes(stored)) {
+        applyTheme(stored, { save: false });
+    } else {
+        applyTheme('auto', { save: false });
+    }
+}
+
+window.onYouTubeIframeAPIReady = function onYouTubeIframeAPIReady() {
+    console.log('YouTube API ready');
+};
+
+window.addEventListener('load', () => {
+    initTheme();
+    updateTerminalInfo();
+    initProgressBar();
+    setTerminalState('idle');
+
+    document.getElementById('yt-url').focus();
+    document.getElementById('play-btn').addEventListener('click', loadAudio);
+    document.getElementById('paste-play-btn').addEventListener('click', pasteAndPlay);
+    document.getElementById('clear-btn').addEventListener('click', clearAll);
+    document.getElementById('yt-url').addEventListener('keypress', e => {
+        if (e.key === 'Enter') {
+            loadAudio();
+        }
+    });
+    document.getElementById('volume-slider').addEventListener('input', e => setVolume(e.target.value));
+    document.getElementById('loop-btn').addEventListener('click', toggleLoop);
+    document.getElementById('backward-btn').addEventListener('click', seekBackward);
+    document.getElementById('forward-btn').addEventListener('click', seekForward);
+    document.getElementById('play-pause-btn').addEventListener('click', togglePlayPause);
+    document.querySelectorAll('.theme-toggle button').forEach(btn => {
+        btn.addEventListener('click', () => applyTheme(btn.dataset.theme));
+    });
+});
+
+setInterval(updateTerminalInfo, 2500);
+window.addEventListener('resize', updateTerminalInfo);
+prefersDark.addEventListener('change', () => {
+    if (themePreference === 'auto') {
+        applyTheme('auto', { save: false });
+    }
+});
+
+document.addEventListener('visibilitychange', handleVisibilityChange);
+window.addEventListener('pageshow', event => {
+    if (event.persisted && (isPlaying || pendingPlay) && player) {
+        safePlay({ terminalMessage: 'Resuming after return', showBlockNotice: false });
+    }
+});
+window.addEventListener('focus', () => {
+    if (isPlaying && player) {
+        safePlay({ terminalMessage: 'Keeping playback active', showBlockNotice: false });
+    }
+});
+document.addEventListener('click', handleResumeGesture);
+document.addEventListener('touchend', handleResumeGesture, { passive: true });

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,660 @@
+:root {
+    color-scheme: light;
+    --body-bg: radial-gradient(circle at 10% -10%, rgba(255, 255, 255, 0.85) 0%, #dbe5ff 35%, #c0d3f9 80%);
+    --container-bg: rgba(255, 255, 255, 0.88);
+    --container-border: rgba(255, 255, 255, 0.35);
+    --container-shadow: 0 28px 60px rgba(58, 92, 173, 0.16);
+    --text-primary: #1c1c1e;
+    --text-secondary: #5f5f62;
+    --glass-overlay: rgba(255, 255, 255, 0.55);
+    --input-bg: rgba(245, 245, 248, 0.88);
+    --input-border: rgba(160, 174, 192, 0.45);
+    --input-focus-ring: rgba(10, 132, 255, 0.2);
+    --button-primary: linear-gradient(135deg, #0a84ff 0%, #5e5ce6 100%);
+    --button-primary-solid: #0a84ff;
+    --button-primary-hover: #409cff;
+    --button-secondary: rgba(10, 132, 255, 0.12);
+    --button-secondary-text: #0a84ff;
+    --divider: rgba(60, 60, 67, 0.18);
+    --surface-muted: rgba(242, 245, 255, 0.85);
+    --status-playing: #30d158;
+    --status-paused: #ffd60a;
+    --status-loading: #0a84ff;
+    --status-error: #ff453a;
+    --terminal-bg: rgba(22, 22, 26, 0.92);
+    --terminal-text: #f5f5f7;
+    --terminal-prompt: #98a0ff;
+    --terminal-divider: rgba(245, 245, 247, 0.12);
+    --progress-track: rgba(142, 142, 147, 0.24);
+    --thumb-bg: #ffffff;
+    --card-outline: rgba(255, 255, 255, 0.25);
+    --icon-glow: rgba(95, 92, 230, 0.18);
+}
+
+body[data-theme="dark"] {
+    color-scheme: dark;
+    --body-bg: radial-gradient(circle at 5% -15%, rgba(54, 61, 95, 0.75) 0%, #090b14 55%, #05060b 100%);
+    --container-bg: rgba(24, 24, 32, 0.86);
+    --container-border: rgba(255, 255, 255, 0.06);
+    --container-shadow: 0 38px 60px rgba(0, 0, 0, 0.55);
+    --text-primary: #f4f4f8;
+    --text-secondary: #c2c2cc;
+    --glass-overlay: rgba(74, 74, 94, 0.6);
+    --input-bg: rgba(42, 45, 58, 0.82);
+    --input-border: rgba(124, 135, 160, 0.3);
+    --input-focus-ring: rgba(99, 230, 226, 0.24);
+    --button-primary: linear-gradient(135deg, #3f8cff 0%, #7d4dff 100%);
+    --button-primary-solid: #3f8cff;
+    --button-primary-hover: #63a4ff;
+    --button-secondary: rgba(99, 230, 226, 0.12);
+    --button-secondary-text: #63e6e2;
+    --divider: rgba(255, 255, 255, 0.08);
+    --surface-muted: rgba(46, 46, 68, 0.76);
+    --terminal-bg: rgba(12, 12, 18, 0.94);
+    --terminal-text: #d9e0ff;
+    --terminal-prompt: #7dd3fc;
+    --terminal-divider: rgba(141, 141, 153, 0.18);
+    --progress-track: rgba(199, 199, 204, 0.25);
+    --thumb-bg: rgba(14, 142, 255, 1);
+    --card-outline: rgba(255, 255, 255, 0.08);
+    --icon-glow: rgba(99, 230, 226, 0.16);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--body-bg);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 28px 18px;
+    color: var(--text-primary);
+    transition: background 0.5s ease, color 0.3s ease;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.container {
+    background: var(--container-bg);
+    backdrop-filter: blur(30px) saturate(160%);
+    border-radius: 28px;
+    padding: 34px 30px 32px;
+    box-shadow: var(--container-shadow);
+    width: min(440px, 100%);
+    border: 1px solid var(--container-border);
+    position: relative;
+    overflow: hidden;
+}
+
+.container::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.04));
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.header {
+    text-align: center;
+    margin-bottom: 24px;
+    position: relative;
+    z-index: 2;
+}
+
+.logo {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 18px 8px 12px;
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 18px 40px rgba(10, 132, 255, 0.18);
+}
+
+.logo-icon {
+    width: 54px;
+    height: 54px;
+    filter: drop-shadow(0 12px 24px rgba(10, 132, 255, 0.28));
+}
+
+.logo-text {
+    font-size: 2.4rem;
+    font-weight: 700;
+    letter-spacing: -0.6px;
+    background: linear-gradient(130deg, rgba(255, 255, 255, 0.92) 5%, rgba(99, 230, 226, 0.75) 45%, rgba(10, 132, 255, 0.9) 70%, rgba(94, 92, 230, 0.85) 100%);
+    -webkit-background-clip: text;
+    color: transparent;
+    text-shadow: 0 18px 40px rgba(15, 35, 95, 0.3);
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 0.96rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-top: 10px;
+}
+
+.theme-toggle {
+    display: inline-flex;
+    padding: 4px;
+    background: rgba(255, 255, 255, 0.16);
+    border-radius: 18px;
+    border: 1px solid var(--card-outline);
+    margin: 0 auto 26px;
+    position: relative;
+    z-index: 2;
+    gap: 4px;
+}
+
+.theme-toggle button {
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    padding: 8px 14px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    border-radius: 14px;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.theme-toggle button.active {
+    background: rgba(10, 132, 255, 0.18);
+    color: var(--text-primary);
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+.theme-toggle .icon svg {
+    width: 20px;
+    height: 20px;
+}
+
+.input-section {
+    margin-bottom: 18px;
+    position: relative;
+    z-index: 2;
+}
+
+.url-input {
+    width: 100%;
+    padding: 14px 18px;
+    border: 1px solid var(--input-border);
+    border-radius: 18px;
+    font-size: 16px;
+    background: var(--input-bg);
+    color: var(--text-primary);
+    outline: none;
+    transition: border 0.2s ease, background 0.3s ease, box-shadow 0.2s ease;
+}
+
+.url-input:focus {
+    border-color: var(--button-primary-solid);
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 0 0 4px var(--input-focus-ring);
+}
+
+.error {
+    background: rgba(255, 69, 58, 0.14);
+    color: var(--status-error);
+    padding: 12px 16px;
+    border-radius: 14px;
+    margin: 10px 0 18px;
+    display: none;
+    font-size: 0.9rem;
+    border-left: 3px solid var(--status-error);
+}
+
+.button-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 24px;
+    position: relative;
+    z-index: 2;
+}
+
+.btn {
+    padding: 12px 14px;
+    border-radius: 16px;
+    font-size: 15px;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    position: relative;
+}
+
+.btn .icon {
+    display: inline-flex;
+    padding: 8px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.16);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 12px 20px var(--icon-glow);
+}
+
+.btn .icon svg {
+    width: 20px;
+    height: 20px;
+    display: block;
+}
+
+.btn-primary {
+    background: var(--button-primary);
+    color: #fff;
+    box-shadow: 0 16px 26px rgba(10, 132, 255, 0.25);
+}
+
+.btn-primary:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 32px rgba(10, 132, 255, 0.28);
+    filter: brightness(1.03);
+}
+
+.btn-secondary {
+    background: var(--button-secondary);
+    color: var(--button-secondary-text);
+    border: 1px solid rgba(10, 132, 255, 0.24);
+}
+
+.btn-secondary:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 22px rgba(99, 230, 226, 0.25);
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none !important;
+    box-shadow: none !important;
+}
+
+.loading {
+    text-align: center;
+    padding: 20px 16px;
+    display: none;
+    color: var(--text-secondary);
+}
+
+.spinner {
+    width: 26px;
+    height: 26px;
+    border: 3px solid rgba(10, 132, 255, 0.14);
+    border-top: 3px solid var(--button-primary-solid);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 12px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.player-card {
+    background: var(--surface-muted);
+    border-radius: 20px;
+    padding: 24px;
+    margin-bottom: 22px;
+    display: none;
+    position: relative;
+    z-index: 2;
+    border: 1px solid var(--card-outline);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.song-info {
+    text-align: center;
+    margin-bottom: 18px;
+}
+
+.song-title {
+    font-size: 1.18rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    line-height: 1.35;
+    margin-bottom: 6px;
+}
+
+.song-status {
+    font-size: 0.92rem;
+    color: var(--text-secondary);
+}
+
+.progress-section {
+    margin-bottom: 22px;
+}
+
+.time-display {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.progress-container {
+    position: relative;
+    height: 6px;
+    background: var(--progress-track);
+    border-radius: 3px;
+    cursor: pointer;
+    touch-action: none;
+}
+
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(135deg, var(--button-primary-solid) 10%, #5e5ce6 100%);
+    border-radius: 3px;
+    width: 0%;
+    transition: width 0.15s linear;
+}
+
+.progress-thumb {
+    position: absolute;
+    top: 50%;
+    left: 0%;
+    width: 18px;
+    height: 18px;
+    background: var(--thumb-bg);
+    border: 3px solid var(--button-primary-solid);
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    cursor: grab;
+    box-shadow: 0 4px 12px rgba(10, 132, 255, 0.25);
+    transition: transform 0.15s ease;
+    touch-action: none;
+}
+
+.progress-thumb:active {
+    cursor: grabbing;
+    transform: translate(-50%, -50%) scale(1.15);
+}
+
+.main-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 28px;
+    margin-bottom: 24px;
+}
+
+.control-btn {
+    width: 54px;
+    height: 54px;
+    border-radius: 26px;
+    border: none;
+    background: rgba(255, 255, 255, 0.82);
+    color: var(--button-primary-solid);
+    font-size: 24px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 12px 18px rgba(10, 132, 255, 0.18);
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.25s ease;
+}
+
+.control-btn .icon svg {
+    width: 26px;
+    height: 26px;
+}
+
+.control-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 28px rgba(10, 132, 255, 0.24);
+}
+
+.control-btn:active {
+    transform: scale(0.95);
+}
+
+.play-btn {
+    width: 68px;
+    height: 68px;
+    background: var(--button-primary);
+    color: #fff;
+}
+
+.play-btn .icon-pause {
+    display: none;
+}
+
+.play-btn.is-playing .icon-play {
+    display: none;
+}
+
+.play-btn.is-playing .icon-pause {
+    display: inline-flex;
+}
+
+.secondary-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 18px;
+    flex-wrap: wrap;
+}
+
+.volume-control {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+}
+
+.volume-icon svg {
+    width: 24px;
+    height: 24px;
+}
+
+.volume-slider {
+    flex: 1;
+    -webkit-appearance: none;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--progress-track);
+    outline: none;
+    cursor: pointer;
+}
+
+.volume-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--thumb-bg);
+    border: 3px solid var(--button-primary-solid);
+    box-shadow: 0 3px 10px rgba(10, 132, 255, 0.2);
+}
+
+.volume-slider::-moz-range-thumb {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--thumb-bg);
+    border: 3px solid var(--button-primary-solid);
+    box-shadow: 0 3px 10px rgba(10, 132, 255, 0.2);
+}
+
+.loop-toggle {
+    padding: 10px 18px;
+    border-radius: 20px;
+    border: 1px solid rgba(10, 132, 255, 0.24);
+    background: rgba(10, 132, 255, 0.12);
+    color: var(--button-secondary-text);
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.loop-toggle .icon svg {
+    width: 22px;
+    height: 22px;
+}
+
+.loop-toggle.active,
+.loop-toggle[aria-pressed="true"] {
+    background: rgba(10, 132, 255, 0.22);
+    color: #fff;
+    box-shadow: 0 14px 26px rgba(10, 132, 255, 0.2);
+}
+
+.mac-terminal {
+    background: var(--terminal-bg);
+    color: var(--terminal-text);
+    border-radius: 20px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 24px 40px rgba(0, 0, 0, 0.35);
+}
+
+.mac-terminal-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 18px;
+    background: rgba(255, 255, 255, 0.06);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.traffic-light {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.45);
+}
+
+.traffic-red { background: #ff5f57; }
+.traffic-yellow { background: #febb2e; }
+.traffic-green { background: #28c840; }
+
+.mac-terminal-title {
+    margin-left: auto;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.mac-terminal-body {
+    padding: 18px 22px 22px;
+    font-family: "SF Mono", "Menlo", "Monaco", monospace;
+    font-size: 0.84rem;
+    line-height: 1.6;
+}
+
+.terminal-line {
+    display: flex;
+    gap: 12px;
+    align-items: baseline;
+}
+
+.prompt {
+    color: var(--terminal-prompt);
+}
+
+.terminal-divider {
+    height: 1px;
+    background: var(--terminal-divider);
+    margin: 12px 0 14px;
+}
+
+.status-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--status-loading);
+    box-shadow: 0 0 12px rgba(10, 132, 255, 0.35);
+    transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.status-dot.playing {
+    background: var(--status-playing);
+    box-shadow: 0 0 12px rgba(48, 209, 88, 0.45);
+}
+
+.status-dot.paused {
+    background: var(--status-paused);
+    box-shadow: 0 0 12px rgba(255, 214, 10, 0.4);
+}
+
+.status-dot.loading {
+    background: var(--status-loading);
+    box-shadow: 0 0 12px rgba(10, 132, 255, 0.42);
+}
+
+.status-dot.error {
+    background: var(--status-error);
+    box-shadow: 0 0 12px rgba(255, 69, 58, 0.42);
+}
+
+#youtube-player {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    left: -9999px;
+    visibility: hidden;
+}
+
+@media (max-width: 480px) {
+    body {
+        padding: 22px 14px;
+    }
+
+    .container {
+        padding: 28px 24px;
+    }
+
+    .button-row {
+        grid-template-columns: 1fr;
+    }
+
+    .theme-toggle {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .mac-terminal-body {
+        font-size: 0.8rem;
+    }
+
+    .main-controls {
+        gap: 22px;
+    }
+}


### PR DESCRIPTION
## Summary
- split the single-page implementation into dedicated HTML, CSS, and JS files while introducing a liquid-glass brand header and custom SVG iconography
- translate UI copy and the stream monitor terminal to English with visuals that follow the active light or dark theme
- harden playback logic for mobile devices by tuning buffering recovery, loop state handling, and play/pause controls

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4bb1e82a8832593ec61d25f4bbb40